### PR TITLE
add/update use a parameter struct that hides the Y/N bool

### DIFF
--- a/kemp.go
+++ b/kemp.go
@@ -95,10 +95,10 @@ func (c *Client) Request(cmd string, parameters map[string]string, data interfac
 		params.Set(key, val)
 	}
 
-	requestUrl := fmt.Sprintf("%s%s?%s", c.endpoint, cmd, params.Encode())
-	req, err := http.NewRequest("GET", requestUrl, nil)
+	requestURL := fmt.Sprintf("%s%s?%s", c.endpoint, cmd, params.Encode())
+	req, err := http.NewRequest("GET", requestURL, nil)
 	if err != nil {
-		return errgo.NoteMask(err, fmt.Sprintf("kemp request to '%s' failed", requestUrl), errgo.Any)
+		return errgo.NoteMask(err, fmt.Sprintf("kemp request to '%s' failed", requestURL), errgo.Any)
 	}
 
 	req.SetBasicAuth(c.user, c.password)
@@ -110,7 +110,7 @@ func (c *Client) Request(cmd string, parameters map[string]string, data interfac
 
 	res, err := client.Do(req)
 	if err != nil {
-		return errgo.NoteMask(err, fmt.Sprintf("kemp request to '%s' failed", requestUrl), errgo.Any)
+		return errgo.NoteMask(err, fmt.Sprintf("kemp request to '%s' failed", requestURL), errgo.Any)
 	}
 
 	if res.StatusCode >= 400 {

--- a/virtualservices.go
+++ b/virtualservices.go
@@ -24,7 +24,7 @@ type VirtualServiceParams struct {
 	Port            string
 	Protocol        string
 	CheckType       string
-	CheckUrl        string
+	CheckURL        string
 	CheckPort       string
 	SSLAcceleration bool
 	Transparent     bool
@@ -62,7 +62,7 @@ type VirtualService struct {
 	ClientCert       string
 	ErrorCode        string
 	CertFile         string
-	CheckUrl         string
+	CheckURL         string `xml:"CheckUrl"`
 	CheckUse11       string `xml:"CheckUse1.1"`
 	MatchLen         string
 	CheckUseGet      string
@@ -206,8 +206,8 @@ func (c *Client) UpdateVirtualService(id string, vs VirtualServiceParams) (Virtu
 	if vs.CheckType != "" {
 		parameters["checktype"] = vs.CheckType
 	}
-	if vs.CheckUrl != "" {
-		parameters["checkurl"] = vs.CheckUrl
+	if vs.CheckURL != "" {
+		parameters["checkurl"] = vs.CheckURL
 	}
 	if vs.CheckPort != "" {
 		parameters["checkport"] = vs.CheckPort
@@ -258,8 +258,8 @@ func (c *Client) AddVirtualService(vs VirtualServiceParams) (VirtualService, err
 	if vs.CheckType != "" {
 		parameters["checktype"] = vs.CheckType
 	}
-	if vs.CheckUrl != "" {
-		parameters["checkurl"] = vs.CheckUrl
+	if vs.CheckURL != "" {
+		parameters["checkurl"] = vs.CheckURL
 	}
 	if vs.CheckPort != "" {
 		parameters["checkport"] = vs.CheckPort


### PR DESCRIPTION
The kemp API expects 'Y' or 'N' for booleans. This is now hidden from users of the kemp-client.
